### PR TITLE
feat: 구글 OAuth 로그인 페이지 (#2)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -25,12 +25,14 @@ apiClient.interceptors.request.use((config) => {
 })
 
 // 응답 인터셉터: 401/403 → 로그아웃 후 /login 리다이렉트
+// 단, 로그인 요청 자체(/api/auth/google)는 제외 (무한 리다이렉트 방지)
 apiClient.interceptors.response.use(
   (response) => response,
   (error: unknown) => {
     if (axios.isAxiosError(error)) {
       const status = error.response?.status
-      if (status === 401 || status === 403) {
+      const url = error.config?.url ?? ''
+      if ((status === 401 || status === 403) && !url.includes('/api/auth/google')) {
         localStorage.removeItem('auth-storage')
         window.location.href = '/login'
       }

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -93,7 +93,6 @@ function BackgroundCanvas() {
 export default function LoginPage() {
   const { token, handleGoogleSuccess } = useAuth()
   const [error, setError] = useState<string | null>(null)
-  const [isHovered, setIsHovered] = useState(false)
 
   if (token) return <Navigate to="/app" replace />
 
@@ -104,7 +103,6 @@ export default function LoginPage() {
     >
       <BackgroundCanvas />
 
-      {/* 배경 글로우 오브 */}
       <div className="absolute top-1/4 left-1/3 w-96 h-96 rounded-full pointer-events-none"
         style={{ background: 'radial-gradient(circle, rgba(124,58,237,0.15) 0%, transparent 70%)', filter: 'blur(40px)' }} />
       <div className="absolute bottom-1/3 right-1/4 w-64 h-64 rounded-full pointer-events-none"
@@ -154,48 +152,47 @@ export default function LoginPage() {
 
         <div className="w-full h-px" style={{ background: 'rgba(255,255,255,0.06)' }} />
 
-        {/* GoogleLogin: 실제 인증 처리 (숨김) */}
-        <div style={{ display: 'none' }}>
-          <GoogleLogin
-            onSuccess={(res) => {
-              if (res.credential) {
-                handleGoogleSuccess(res.credential).catch(() => {
-                  setError('로그인에 실패했어요. 다시 시도해주세요.')
-                })
-              }
-            }}
-            onError={() => setError('Google 인증에 실패했어요.')}
-            useOneTap
-          />
-        </div>
-
-        {/* 커스텀 구글 버튼 — OneTap이 자동으로 뜨므로 클릭 유도 문구 */}
+        {/* 버튼 영역: 커스텀 디자인 위에 GoogleLogin 투명 오버레이 */}
         <div className="w-full flex flex-col gap-3">
-          <button
-            onClick={() => {
-              // OneTap prompt 수동 트리거 (google.accounts.id가 로드된 경우)
-              if (typeof window !== 'undefined' && (window as unknown as { google?: { accounts?: { id?: { prompt?: () => void } } } }).google?.accounts?.id?.prompt) {
-                (window as unknown as { google: { accounts: { id: { prompt: () => void } } } }).google.accounts.id.prompt()
-              }
-            }}
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
-            className="w-full flex items-center justify-center gap-3 py-3 px-6 rounded-xl font-medium text-sm transition-all duration-200 cursor-pointer"
-            style={{
-              background: isHovered ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0.06)',
-              border: isHovered ? '1px solid rgba(167,139,250,0.4)' : '1px solid rgba(255,255,255,0.1)',
-              color: '#f1f0f5',
-              boxShadow: isHovered ? '0 0 20px rgba(167,139,250,0.15)' : 'none',
-            }}
-          >
-            <svg width="18" height="18" viewBox="0 0 18 18">
-              <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4" />
-              <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853" />
-              <path d="M3.964 10.707A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.707V4.961H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.039l3.007-2.332z" fill="#FBBC05" />
-              <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.96L3.964 7.293C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335" />
-            </svg>
-            Google로 시작하기
-          </button>
+          <div className="relative w-full h-12">
+            {/* 커스텀 스타일 버튼 (시각적 레이어) */}
+            <div
+              className="absolute inset-0 flex items-center justify-center gap-3 rounded-xl font-medium text-sm pointer-events-none"
+              style={{
+                background: 'rgba(255,255,255,0.06)',
+                border: '1px solid rgba(255,255,255,0.1)',
+                color: '#f1f0f5',
+              }}
+            >
+              <svg width="18" height="18" viewBox="0 0 18 18">
+                <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4" />
+                <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853" />
+                <path d="M3.964 10.707A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.707V4.961H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.039l3.007-2.332z" fill="#FBBC05" />
+                <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.96L3.964 7.293C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335" />
+              </svg>
+              Google로 시작하기
+            </div>
+
+            {/* GoogleLogin 투명 오버레이 (실제 클릭 처리) */}
+            <div
+              className="absolute inset-0 overflow-hidden rounded-xl"
+              style={{ opacity: 0 }}
+            >
+              <GoogleLogin
+                onSuccess={(res) => {
+                  if (res.credential) {
+                    setError(null)
+                    handleGoogleSuccess(res.credential).catch(() => {
+                      setError('로그인에 실패했어요. 다시 시도해주세요.')
+                    })
+                  }
+                }}
+                onError={() => setError('Google 인증에 실패했어요.')}
+                width="360"
+                size="large"
+              />
+            </div>
+          </div>
 
           {error && (
             <p className="text-xs text-center" style={{ color: '#f87171' }}>{error}</p>

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -90,19 +90,15 @@ function BackgroundCanvas() {
 }
 
 export default function LoginPage() {
-  const { token, login } = useAuth()
   const [isHovered, setIsHovered] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { token, login } = useAuth((msg) => setError(msg))
 
   if (token) return <Navigate to="/app" replace />
 
   const handleLogin = () => {
     setError(null)
-    try {
-      login()
-    } catch {
-      setError('로그인에 실패했어요. 다시 시도해주세요.')
-    }
+    login()
   }
 
   return (

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -1,4 +1,211 @@
-// Phase 2에서 구현 예정
+import { useEffect, useRef, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import { GoogleLogin } from '@react-oauth/google'
+import { useAuth } from '../../hooks/useAuth'
+
+function BackgroundCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const resize = () => {
+      canvas.width = window.innerWidth
+      canvas.height = window.innerHeight
+    }
+    resize()
+    window.addEventListener('resize', resize)
+
+    type Particle = {
+      x: number; y: number; vx: number; vy: number
+      r: number; color: string; alpha: number
+    }
+
+    const colors = ['#a78bfa', '#818cf8', '#c084fc', '#7c3aed', '#6366f1']
+    const particles: Particle[] = Array.from({ length: 40 }, () => ({
+      x: Math.random() * window.innerWidth,
+      y: Math.random() * window.innerHeight,
+      vx: (Math.random() - 0.5) * 0.4,
+      vy: (Math.random() - 0.5) * 0.4,
+      r: Math.random() * 3 + 2,
+      color: colors[Math.floor(Math.random() * colors.length)],
+      alpha: Math.random() * 0.5 + 0.2,
+    }))
+
+    let animId: number
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+      for (let i = 0; i < particles.length; i++) {
+        for (let j = i + 1; j < particles.length; j++) {
+          const dx = particles[i].x - particles[j].x
+          const dy = particles[i].y - particles[j].y
+          const dist = Math.sqrt(dx * dx + dy * dy)
+          if (dist < 160) {
+            ctx.beginPath()
+            ctx.moveTo(particles[i].x, particles[i].y)
+            ctx.lineTo(particles[j].x, particles[j].y)
+            ctx.strokeStyle = `rgba(167,139,250,${0.12 * (1 - dist / 160)})`
+            ctx.lineWidth = 1
+            ctx.stroke()
+          }
+        }
+      }
+
+      for (const p of particles) {
+        const grd = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, p.r * 5)
+        grd.addColorStop(0, `${p.color}55`)
+        grd.addColorStop(1, 'transparent')
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, p.r * 5, 0, Math.PI * 2)
+        ctx.fillStyle = grd
+        ctx.fill()
+
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2)
+        ctx.fillStyle = p.color
+        ctx.globalAlpha = p.alpha
+        ctx.fill()
+        ctx.globalAlpha = 1
+
+        p.x += p.vx
+        p.y += p.vy
+        if (p.x < 0 || p.x > canvas.width) p.vx *= -1
+        if (p.y < 0 || p.y > canvas.height) p.vy *= -1
+      }
+
+      animId = requestAnimationFrame(draw)
+    }
+    draw()
+
+    return () => {
+      cancelAnimationFrame(animId)
+      window.removeEventListener('resize', resize)
+    }
+  }, [])
+
+  return <canvas ref={canvasRef} className="absolute inset-0 w-full h-full" style={{ opacity: 0.6 }} />
+}
+
 export default function LoginPage() {
-  return <div>LoginPage - TODO</div>
+  const { token, handleGoogleSuccess } = useAuth()
+  const [error, setError] = useState<string | null>(null)
+  const [isHovered, setIsHovered] = useState(false)
+
+  if (token) return <Navigate to="/app" replace />
+
+  return (
+    <div
+      className="relative min-h-screen flex items-center justify-center overflow-hidden"
+      style={{ background: 'radial-gradient(ellipse at 60% 40%, #1a0a3a 0%, #07070f 60%)' }}
+    >
+      <BackgroundCanvas />
+
+      {/* 배경 글로우 오브 */}
+      <div className="absolute top-1/4 left-1/3 w-96 h-96 rounded-full pointer-events-none"
+        style={{ background: 'radial-gradient(circle, rgba(124,58,237,0.15) 0%, transparent 70%)', filter: 'blur(40px)' }} />
+      <div className="absolute bottom-1/3 right-1/4 w-64 h-64 rounded-full pointer-events-none"
+        style={{ background: 'radial-gradient(circle, rgba(99,102,241,0.12) 0%, transparent 70%)', filter: 'blur(40px)' }} />
+
+      {/* 로그인 카드 */}
+      <div
+        className="relative z-10 flex flex-col items-center gap-8 px-10 py-12 rounded-3xl"
+        style={{
+          background: 'rgba(255,255,255,0.04)',
+          backdropFilter: 'blur(24px)',
+          border: '1px solid rgba(255,255,255,0.08)',
+          boxShadow: '0 32px 80px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.06)',
+          minWidth: 360,
+        }}
+      >
+        {/* 로고 */}
+        <div className="flex flex-col items-center gap-3">
+          <div
+            className="w-12 h-12 rounded-2xl flex items-center justify-center"
+            style={{
+              background: 'linear-gradient(135deg, #7c3aed, #4f46e5)',
+              boxShadow: '0 0 24px rgba(124,58,237,0.5)',
+            }}
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+              <circle cx="12" cy="12" r="3" fill="white" />
+              <circle cx="4" cy="6" r="2" fill="white" fillOpacity="0.6" />
+              <circle cx="20" cy="6" r="2" fill="white" fillOpacity="0.6" />
+              <circle cx="4" cy="18" r="2" fill="white" fillOpacity="0.6" />
+              <circle cx="20" cy="18" r="2" fill="white" fillOpacity="0.6" />
+              <line x1="12" y1="12" x2="4" y2="6" stroke="white" strokeOpacity="0.4" strokeWidth="1.5" />
+              <line x1="12" y1="12" x2="20" y2="6" stroke="white" strokeOpacity="0.4" strokeWidth="1.5" />
+              <line x1="12" y1="12" x2="4" y2="18" stroke="white" strokeOpacity="0.4" strokeWidth="1.5" />
+              <line x1="12" y1="12" x2="20" y2="18" stroke="white" strokeOpacity="0.4" strokeWidth="1.5" />
+            </svg>
+          </div>
+          <div className="text-center">
+            <h1 className="text-2xl font-semibold tracking-tight" style={{ color: '#f1f0f5' }}>
+              Memo Graph
+            </h1>
+            <p className="text-sm mt-1" style={{ color: '#9b97b2' }}>
+              메모를 연결하고, 지식을 시각화하세요
+            </p>
+          </div>
+        </div>
+
+        <div className="w-full h-px" style={{ background: 'rgba(255,255,255,0.06)' }} />
+
+        {/* GoogleLogin: 실제 인증 처리 (숨김) */}
+        <div style={{ display: 'none' }}>
+          <GoogleLogin
+            onSuccess={(res) => {
+              if (res.credential) {
+                handleGoogleSuccess(res.credential).catch(() => {
+                  setError('로그인에 실패했어요. 다시 시도해주세요.')
+                })
+              }
+            }}
+            onError={() => setError('Google 인증에 실패했어요.')}
+            useOneTap
+          />
+        </div>
+
+        {/* 커스텀 구글 버튼 — OneTap이 자동으로 뜨므로 클릭 유도 문구 */}
+        <div className="w-full flex flex-col gap-3">
+          <button
+            onClick={() => {
+              // OneTap prompt 수동 트리거 (google.accounts.id가 로드된 경우)
+              if (typeof window !== 'undefined' && (window as unknown as { google?: { accounts?: { id?: { prompt?: () => void } } } }).google?.accounts?.id?.prompt) {
+                (window as unknown as { google: { accounts: { id: { prompt: () => void } } } }).google.accounts.id.prompt()
+              }
+            }}
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+            className="w-full flex items-center justify-center gap-3 py-3 px-6 rounded-xl font-medium text-sm transition-all duration-200 cursor-pointer"
+            style={{
+              background: isHovered ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0.06)',
+              border: isHovered ? '1px solid rgba(167,139,250,0.4)' : '1px solid rgba(255,255,255,0.1)',
+              color: '#f1f0f5',
+              boxShadow: isHovered ? '0 0 20px rgba(167,139,250,0.15)' : 'none',
+            }}
+          >
+            <svg width="18" height="18" viewBox="0 0 18 18">
+              <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4" />
+              <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853" />
+              <path d="M3.964 10.707A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.707V4.961H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.039l3.007-2.332z" fill="#FBBC05" />
+              <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.96L3.964 7.293C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335" />
+            </svg>
+            Google로 시작하기
+          </button>
+
+          {error && (
+            <p className="text-xs text-center" style={{ color: '#f87171' }}>{error}</p>
+          )}
+        </div>
+
+        <p className="text-xs" style={{ color: '#6b6880' }}>
+          로그인 시 개인 지식 그래프 공간이 생성됩니다
+        </p>
+      </div>
+    </div>
+  )
 }

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
 import { Navigate } from 'react-router-dom'
-import { GoogleLogin } from '@react-oauth/google'
 import { useAuth } from '../../hooks/useAuth'
 
 function BackgroundCanvas() {
@@ -91,10 +90,20 @@ function BackgroundCanvas() {
 }
 
 export default function LoginPage() {
-  const { token, handleGoogleSuccess } = useAuth()
+  const { token, login } = useAuth()
+  const [isHovered, setIsHovered] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   if (token) return <Navigate to="/app" replace />
+
+  const handleLogin = () => {
+    setError(null)
+    try {
+      login()
+    } catch {
+      setError('로그인에 실패했어요. 다시 시도해주세요.')
+    }
+  }
 
   return (
     <div
@@ -152,47 +161,27 @@ export default function LoginPage() {
 
         <div className="w-full h-px" style={{ background: 'rgba(255,255,255,0.06)' }} />
 
-        {/* 버튼 영역: 커스텀 디자인 위에 GoogleLogin 투명 오버레이 */}
         <div className="w-full flex flex-col gap-3">
-          <div className="relative w-full h-12">
-            {/* 커스텀 스타일 버튼 (시각적 레이어) */}
-            <div
-              className="absolute inset-0 flex items-center justify-center gap-3 rounded-xl font-medium text-sm pointer-events-none"
-              style={{
-                background: 'rgba(255,255,255,0.06)',
-                border: '1px solid rgba(255,255,255,0.1)',
-                color: '#f1f0f5',
-              }}
-            >
-              <svg width="18" height="18" viewBox="0 0 18 18">
-                <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4" />
-                <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853" />
-                <path d="M3.964 10.707A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.707V4.961H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.039l3.007-2.332z" fill="#FBBC05" />
-                <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.96L3.964 7.293C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335" />
-              </svg>
-              Google로 시작하기
-            </div>
-
-            {/* GoogleLogin 투명 오버레이 (실제 클릭 처리) */}
-            <div
-              className="absolute inset-0 overflow-hidden rounded-xl"
-              style={{ opacity: 0 }}
-            >
-              <GoogleLogin
-                onSuccess={(res) => {
-                  if (res.credential) {
-                    setError(null)
-                    handleGoogleSuccess(res.credential).catch(() => {
-                      setError('로그인에 실패했어요. 다시 시도해주세요.')
-                    })
-                  }
-                }}
-                onError={() => setError('Google 인증에 실패했어요.')}
-                width="360"
-                size="large"
-              />
-            </div>
-          </div>
+          <button
+            onClick={handleLogin}
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+            className="w-full flex items-center justify-center gap-3 py-3 px-6 rounded-xl font-medium text-sm transition-all duration-200 cursor-pointer"
+            style={{
+              background: isHovered ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0.06)',
+              border: isHovered ? '1px solid rgba(167,139,250,0.4)' : '1px solid rgba(255,255,255,0.1)',
+              color: '#f1f0f5',
+              boxShadow: isHovered ? '0 0 20px rgba(167,139,250,0.15)' : 'none',
+            }}
+          >
+            <svg width="18" height="18" viewBox="0 0 18 18">
+              <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4" />
+              <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853" />
+              <path d="M3.964 10.707A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.707V4.961H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.039l3.007-2.332z" fill="#FBBC05" />
+              <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.96L3.964 7.293C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335" />
+            </svg>
+            Google로 시작하기
+          </button>
 
           {error && (
             <p className="text-xs text-center" style={{ color: '#f87171' }}>{error}</p>

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { Navigate } from 'react-router-dom'
+import { GoogleLogin } from '@react-oauth/google'
 import { useAuth } from '../../hooks/useAuth'
 
 function BackgroundCanvas() {
@@ -92,14 +93,9 @@ function BackgroundCanvas() {
 export default function LoginPage() {
   const [isHovered, setIsHovered] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const { token, login } = useAuth((msg) => setError(msg))
+  const { token, handleCredential } = useAuth((msg) => setError(msg))
 
   if (token) return <Navigate to="/app" replace />
-
-  const handleLogin = () => {
-    setError(null)
-    login()
-  }
 
   return (
     <div
@@ -158,26 +154,46 @@ export default function LoginPage() {
         <div className="w-full h-px" style={{ background: 'rgba(255,255,255,0.06)' }} />
 
         <div className="w-full flex flex-col gap-3">
-          <button
-            onClick={handleLogin}
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
-            className="w-full flex items-center justify-center gap-3 py-3 px-6 rounded-xl font-medium text-sm transition-all duration-200 cursor-pointer"
-            style={{
-              background: isHovered ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0.06)',
-              border: isHovered ? '1px solid rgba(167,139,250,0.4)' : '1px solid rgba(255,255,255,0.1)',
-              color: '#f1f0f5',
-              boxShadow: isHovered ? '0 0 20px rgba(167,139,250,0.15)' : 'none',
-            }}
-          >
-            <svg width="18" height="18" viewBox="0 0 18 18">
-              <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4" />
-              <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853" />
-              <path d="M3.964 10.707A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.707V4.961H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.039l3.007-2.332z" fill="#FBBC05" />
-              <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.96L3.964 7.293C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335" />
-            </svg>
-            Google로 시작하기
-          </button>
+          {/* 커스텀 버튼 위에 GoogleLogin 투명 오버레이 — ID Token 획득 */}
+          <div className="relative w-full h-12">
+            <div
+              onMouseEnter={() => setIsHovered(true)}
+              onMouseLeave={() => setIsHovered(false)}
+              className="absolute inset-0 flex items-center justify-center gap-3 rounded-xl font-medium text-sm pointer-events-none transition-all duration-200"
+              style={{
+                background: isHovered ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0.06)',
+                border: isHovered ? '1px solid rgba(167,139,250,0.4)' : '1px solid rgba(255,255,255,0.1)',
+                color: '#f1f0f5',
+                boxShadow: isHovered ? '0 0 20px rgba(167,139,250,0.15)' : 'none',
+              }}
+            >
+              <svg width="18" height="18" viewBox="0 0 18 18">
+                <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4" />
+                <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853" />
+                <path d="M3.964 10.707A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.707V4.961H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.039l3.007-2.332z" fill="#FBBC05" />
+                <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.96L3.964 7.293C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335" />
+              </svg>
+              Google로 시작하기
+            </div>
+            <div
+              className="absolute inset-0 overflow-hidden rounded-xl"
+              style={{ opacity: 0 }}
+              onMouseEnter={() => setIsHovered(true)}
+              onMouseLeave={() => setIsHovered(false)}
+            >
+              <GoogleLogin
+                onSuccess={(res) => {
+                  if (res.credential) {
+                    setError(null)
+                    void handleCredential(res.credential)
+                  }
+                }}
+                onError={() => setError('Google 인증에 실패했어요.')}
+                width="360"
+                size="large"
+              />
+            </div>
+          </div>
 
           {error && (
             <p className="text-xs text-center" style={{ color: '#f87171' }}>{error}</p>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,28 +1,26 @@
-import { useGoogleLogin } from '@react-oauth/google'
 import { loginWithGoogle, fetchMe } from '../api/auth'
 import { useAuthStore } from '../store/useAuthStore'
 
 export function useAuth() {
   const { token, user, setAuth, clearAuth } = useAuthStore()
 
-  const login = useGoogleLogin({
-    onSuccess: async (tokenResponse) => {
-      try {
-        const auth = await loginWithGoogle(tokenResponse.access_token)
-        const me = await fetchMe()
-        setAuth(auth.access_token, me)
-        window.location.href = '/app'
-      } catch (e) {
-        console.error('로그인 실패', e)
-      }
-    },
-    onError: (e) => console.error('Google OAuth 실패', e),
-  })
+  // GoogleLogin 컴포넌트의 onSuccess에서 호출: credential = Google ID Token
+  const handleGoogleSuccess = async (credential: string) => {
+    try {
+      const auth = await loginWithGoogle(credential)
+      const me = await fetchMe()
+      setAuth(auth.access_token, me)
+      window.location.href = '/app'
+    } catch (e) {
+      console.error('로그인 실패', e)
+      throw e
+    }
+  }
 
   const logout = () => {
     clearAuth()
     window.location.href = '/login'
   }
 
-  return { token, user, login, logout }
+  return { token, user, handleGoogleSuccess, logout }
 }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,7 +2,7 @@ import { useGoogleLogin } from '@react-oauth/google'
 import { loginWithGoogle, fetchMe } from '../api/auth'
 import { useAuthStore } from '../store/useAuthStore'
 
-export function useAuth() {
+export function useAuth(onError?: (msg: string) => void) {
   const { token, user, setAuth, clearAuth } = useAuthStore()
 
   const login = useGoogleLogin({
@@ -10,7 +10,6 @@ export function useAuth() {
     scope: 'openid email profile',
     onSuccess: async (tokenResponse) => {
       try {
-        // implicit flow + openid scope → id_token이 응답에 포함됨 (타입 미지원이라 캐스팅)
         const idToken = (tokenResponse as unknown as { id_token?: string }).id_token
         const credential = idToken ?? tokenResponse.access_token
         const auth = await loginWithGoogle(credential)
@@ -19,10 +18,13 @@ export function useAuth() {
         window.location.href = '/app'
       } catch (e) {
         console.error('로그인 실패', e)
-        throw e
+        onError?.('로그인에 실패했어요. 다시 시도해주세요.')
       }
     },
-    onError: (e) => console.error('Google OAuth 실패', e),
+    onError: () => {
+      console.error('Google OAuth 실패')
+      onError?.('Google 인증에 실패했어요.')
+    },
   })
 
   const logout = () => {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,36 +1,26 @@
-import { useGoogleLogin } from '@react-oauth/google'
 import { loginWithGoogle, fetchMe } from '../api/auth'
 import { useAuthStore } from '../store/useAuthStore'
 
 export function useAuth(onError?: (msg: string) => void) {
   const { token, user, setAuth, clearAuth } = useAuthStore()
 
-  const login = useGoogleLogin({
-    flow: 'implicit',
-    scope: 'openid email profile',
-    onSuccess: async (tokenResponse) => {
-      try {
-        const idToken = (tokenResponse as unknown as { id_token?: string }).id_token
-        const credential = idToken ?? tokenResponse.access_token
-        const auth = await loginWithGoogle(credential)
-        const me = await fetchMe()
-        setAuth(auth.access_token, me)
-        window.location.href = '/app'
-      } catch (e) {
-        console.error('로그인 실패', e)
-        onError?.('로그인에 실패했어요. 다시 시도해주세요.')
-      }
-    },
-    onError: () => {
-      console.error('Google OAuth 실패')
-      onError?.('Google 인증에 실패했어요.')
-    },
-  })
+  // GoogleLogin 컴포넌트의 onSuccess에서 호출 — credential = Google ID Token
+  const handleCredential = async (credential: string) => {
+    try {
+      const auth = await loginWithGoogle(credential)
+      const me = await fetchMe()
+      setAuth(auth.access_token, me)
+      window.location.href = '/app'
+    } catch (e) {
+      console.error('로그인 실패', e)
+      onError?.('로그인에 실패했어요. 다시 시도해주세요.')
+    }
+  }
 
   const logout = () => {
     clearAuth()
     window.location.href = '/login'
   }
 
-  return { token, user, login, logout }
+  return { token, user, handleCredential, logout }
 }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,26 +1,34 @@
+import { useGoogleLogin } from '@react-oauth/google'
 import { loginWithGoogle, fetchMe } from '../api/auth'
 import { useAuthStore } from '../store/useAuthStore'
 
 export function useAuth() {
   const { token, user, setAuth, clearAuth } = useAuthStore()
 
-  // GoogleLogin 컴포넌트의 onSuccess에서 호출: credential = Google ID Token
-  const handleGoogleSuccess = async (credential: string) => {
-    try {
-      const auth = await loginWithGoogle(credential)
-      const me = await fetchMe()
-      setAuth(auth.access_token, me)
-      window.location.href = '/app'
-    } catch (e) {
-      console.error('로그인 실패', e)
-      throw e
-    }
-  }
+  const login = useGoogleLogin({
+    flow: 'implicit',
+    scope: 'openid email profile',
+    onSuccess: async (tokenResponse) => {
+      try {
+        // implicit flow + openid scope → id_token이 응답에 포함됨 (타입 미지원이라 캐스팅)
+        const idToken = (tokenResponse as unknown as { id_token?: string }).id_token
+        const credential = idToken ?? tokenResponse.access_token
+        const auth = await loginWithGoogle(credential)
+        const me = await fetchMe()
+        setAuth(auth.access_token, me)
+        window.location.href = '/app'
+      } catch (e) {
+        console.error('로그인 실패', e)
+        throw e
+      }
+    },
+    onError: (e) => console.error('Google OAuth 실패', e),
+  })
 
   const logout = () => {
     clearAuth()
     window.location.href = '/login'
   }
 
-  return { token, user, handleGoogleSuccess, logout }
+  return { token, user, login, logout }
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,12 +18,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "noUncheckedSideEffectImports": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- Dark Glassmorphism 스타일 로그인 카드 (유리 효과, 퍼플 글로우)
- Canvas 배경 애니메이션 (노드 + 연결선이 떠다니는 효과)
- `GoogleLogin` 컴포넌트로 Google ID Token 획득 → 백엔드 전달
- One Tap 자동 프롬프트 + 커스텀 스타일 버튼 조합
- 로그인 성공 시 `/app` 리다이렉트
- 에러 메시지 표시 (인증 실패 시)

## 테스트 방법
1. `npm run dev` 실행
2. `localhost:5173` 접속 → `/login`으로 자동 리다이렉트 확인
3. 로그인 카드 + 배경 애니메이션 렌더링 확인
4. Google 로그인 버튼 클릭 → One Tap 팝업 뜨는지 확인
5. 로그인 성공 시 `/app`으로 이동하는지 확인 (백엔드 연결 필요)
6. 이미 로그인된 상태로 `/login` 접속 시 `/app`으로 리다이렉트 확인

Closes #2