### PR TITLE
feat: 앱 레이아웃, 사이드바, 홈 뷰 (#3)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -16,7 +16,10 @@ export async function loginWithGoogle(token: string): Promise<AuthResponse> {
   return res.data
 }
 
-export async function fetchMe(): Promise<MeResponse> {
-  const res = await apiClient.get<MeResponse>('/api/auth/me')
+// token을 직접 받아 헤더에 꽂음 — setAuth 이전에도 인증 요청 가능
+export async function fetchMe(token: string): Promise<MeResponse> {
+  const res = await apiClient.get<MeResponse>('/api/auth/me', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
   return res.data
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -14,7 +14,9 @@ apiClient.interceptors.request.use((config) => {
     try {
       const parsed = JSON.parse(raw) as { state?: { token?: string } }
       const token = parsed?.state?.token
-      if (token) {
+      
+      // 이미 Authorization 헤더가 설정되어 있다면 덮어쓰지 않습니다. (예: fetchMe에서의 수동 설정 보호)
+      if (token && config.headers && !config.headers.Authorization) {
         config.headers.Authorization = `Bearer ${token}`
       }
     } catch {

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -91,7 +91,6 @@ function BackgroundCanvas() {
 }
 
 export default function LoginPage() {
-  const [isHovered, setIsHovered] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const { token, handleCredential } = useAuth((msg) => setError(msg))
 
@@ -154,45 +153,22 @@ export default function LoginPage() {
         <div className="w-full h-px" style={{ background: 'rgba(255,255,255,0.06)' }} />
 
         <div className="w-full flex flex-col gap-3">
-          {/* 커스텀 버튼 위에 GoogleLogin 투명 오버레이 — ID Token 획득 */}
-          <div className="relative w-full h-12">
-            <div
-              onMouseEnter={() => setIsHovered(true)}
-              onMouseLeave={() => setIsHovered(false)}
-              className="absolute inset-0 flex items-center justify-center gap-3 rounded-xl font-medium text-sm pointer-events-none transition-all duration-200"
-              style={{
-                background: isHovered ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0.06)',
-                border: isHovered ? '1px solid rgba(167,139,250,0.4)' : '1px solid rgba(255,255,255,0.1)',
-                color: '#f1f0f5',
-                boxShadow: isHovered ? '0 0 20px rgba(167,139,250,0.15)' : 'none',
+          {/* Google 공식 버튼을 직접 렌더링 (투명 오버레이를 씌우면 Google의 Clickjacking 보안으로 인해 팝업이 뜨지 않음) */}
+          <div className="w-full flex justify-center mt-2 overflow-hidden rounded-xl" style={{ boxShadow: '0 4px 14px rgba(0,0,0,0.2)' }}>
+            <GoogleLogin
+              onSuccess={(res) => {
+                if (res.credential) {
+                  setError(null)
+                  void handleCredential(res.credential)
+                }
               }}
-            >
-              <svg width="18" height="18" viewBox="0 0 18 18">
-                <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4" />
-                <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853" />
-                <path d="M3.964 10.707A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.707V4.961H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.039l3.007-2.332z" fill="#FBBC05" />
-                <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.96L3.964 7.293C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335" />
-              </svg>
-              Google로 시작하기
-            </div>
-            <div
-              className="absolute inset-0 overflow-hidden rounded-xl"
-              style={{ opacity: 0 }}
-              onMouseEnter={() => setIsHovered(true)}
-              onMouseLeave={() => setIsHovered(false)}
-            >
-              <GoogleLogin
-                onSuccess={(res) => {
-                  if (res.credential) {
-                    setError(null)
-                    void handleCredential(res.credential)
-                  }
-                }}
-                onError={() => setError('Google 인증에 실패했어요.')}
-                width="360"
-                size="large"
-              />
-            </div>
+              onError={() => setError('Google 인증에 실패했어요.')}
+              width="360"
+              size="large"
+              theme="filled_black"
+              shape="rectangular"
+              text="continue_with"
+            />
           </div>
 
           {error && (

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -1,0 +1,53 @@
+import MemoInput from './MemoInput'
+import { useAuthStore } from '../../store/useAuthStore'
+
+const SUGGESTIONS = [
+  '오늘 배운 React 19의 새로운 훅들 정리',
+  '독서 메모: 생각에 관한 생각 — 카너먼',
+  '사이드 프로젝트 아이디어: AI 기반 일정 관리',
+]
+
+export default function HomeView() {
+  const user = useAuthStore((s) => s.user)
+  const firstName = user?.email?.split('@')[0] ?? '사용자'
+
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center px-8 gap-10">
+      {/* 인사말 */}
+      <div className="text-center flex flex-col gap-2">
+        <h2
+          className="text-3xl font-semibold tracking-tight"
+          style={{ color: '#f1f0f5' }}
+        >
+          안녕하세요, {firstName}님
+        </h2>
+        <p className="text-sm" style={{ color: '#6b6880' }}>
+          메모를 입력하면 AI가 요약하고 지식 그래프로 연결해드려요
+        </p>
+      </div>
+
+      {/* 입력창 */}
+      <MemoInput />
+
+      {/* 예시 제안 */}
+      <div className="flex flex-col items-center gap-3">
+        <p className="text-xs" style={{ color: '#4b4860' }}>이런 메모는 어떠세요?</p>
+        <div className="flex flex-wrap justify-center gap-2">
+          {SUGGESTIONS.map((s) => (
+            <span
+              key={s}
+              className="text-xs px-3 py-1.5 rounded-full"
+              style={{
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.07)',
+                color: '#6b6880',
+              }}
+            >
+              {s}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/home/MemoInput.tsx
+++ b/src/components/home/MemoInput.tsx
@@ -1,0 +1,120 @@
+import { useState, useRef } from 'react'
+import { useCreateNode } from '../../hooks/useCreateNode'
+import { useUiStore } from '../../store/useUiStore'
+import Toast from '../ui/Toast'
+import axios from 'axios'
+
+export default function MemoInput() {
+  const [text, setText] = useState('')
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'info' } | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const { mutate: createNode, isPending } = useCreateNode()
+  const setViewMode = useUiStore((s) => s.setViewMode)
+
+  const handleSubmit = () => {
+    const trimmed = text.trim()
+    if (!trimmed || isPending) return
+
+    createNode(trimmed, {
+      onSuccess: () => {
+        setText('')
+        setViewMode('2d')
+      },
+      onError: (error) => {
+        if (axios.isAxiosError(error) && error.response?.status === 409) {
+          setToast({ message: '이미 비슷한 메모가 있어요', type: 'info' })
+        } else {
+          setToast({ message: '메모 저장에 실패했어요. 다시 시도해주세요.', type: 'error' })
+        }
+      },
+    })
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  // 입력에 따라 textarea 높이 자동 조절
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value)
+    const el = textareaRef.current
+    if (el) {
+      el.style.height = 'auto'
+      el.style.height = `${Math.min(el.scrollHeight, 160)}px`
+    }
+  }
+
+  return (
+    <>
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+
+      <div
+        className="w-full max-w-2xl rounded-2xl transition-all duration-200"
+        style={{
+          background: 'rgba(255,255,255,0.04)',
+          border: '1px solid rgba(255,255,255,0.08)',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.3)',
+        }}
+      >
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder="메모를 입력하세요... (Enter로 전송, Shift+Enter로 줄바꿈)"
+          rows={1}
+          className="w-full bg-transparent resize-none outline-none px-5 pt-4 pb-2 text-sm leading-relaxed"
+          style={{
+            color: '#f1f0f5',
+            caretColor: '#a78bfa',
+            minHeight: 52,
+          }}
+        />
+
+        {/* 하단 툴바 */}
+        <div className="flex items-center justify-between px-4 pb-3">
+          <span className="text-xs" style={{ color: '#4b4860' }}>
+            {text.length > 0 ? `${text.length}자` : 'Enter로 전송'}
+          </span>
+          <button
+            onClick={handleSubmit}
+            disabled={!text.trim() || isPending}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-150 cursor-pointer"
+            style={{
+              background: text.trim() && !isPending ? '#7c3aed' : 'rgba(255,255,255,0.06)',
+              color: text.trim() && !isPending ? '#fff' : '#4b4860',
+              boxShadow: text.trim() && !isPending ? '0 0 16px rgba(124,58,237,0.4)' : 'none',
+            }}
+          >
+            {isPending ? (
+              <>
+                <svg className="animate-spin" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" strokeOpacity="0.3" />
+                  <path d="M21 12a9 9 0 00-9-9" />
+                </svg>
+                처리 중
+              </>
+            ) : (
+              <>
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="22" y1="2" x2="11" y2="13" />
+                  <polygon points="22 2 15 22 11 13 2 9 22 2" />
+                </svg>
+                전송
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,4 +1,45 @@
-// Phase 3에서 구현 예정
+import { useUiStore } from '../../store/useUiStore'
+import Sidebar from './Sidebar'
+import HomeView from '../home/HomeView'
+
+// Phase 4/5에서 구현 예정
+function GraphView() {
+  return (
+    <div className="flex-1 flex items-center justify-center" style={{ color: '#6b6880' }}>
+      <div className="text-center flex flex-col gap-2">
+        <span className="text-4xl">🕸</span>
+        <p className="text-sm">2D 그래프 뷰 — Phase 4에서 구현 예정</p>
+      </div>
+    </div>
+  )
+}
+
+function TunnelView() {
+  return (
+    <div className="flex-1 flex items-center justify-center" style={{ color: '#6b6880' }}>
+      <div className="text-center flex flex-col gap-2">
+        <span className="text-4xl">🌀</span>
+        <p className="text-sm">3D 터널 뷰 — Phase 5에서 구현 예정</p>
+      </div>
+    </div>
+  )
+}
+
 export default function AppLayout() {
-  return <div>AppLayout - TODO</div>
+  const viewMode = useUiStore((s) => s.viewMode)
+
+  return (
+    <div
+      className="flex h-screen w-screen overflow-hidden"
+      style={{ background: 'radial-gradient(ellipse at 30% 20%, #120a2a 0%, #07070f 60%)' }}
+    >
+      <Sidebar />
+
+      <main className="flex-1 flex overflow-hidden">
+        {viewMode === 'home' && <HomeView />}
+        {viewMode === '2d' && <GraphView />}
+        {viewMode === '3d' && <TunnelView />}
+      </main>
+    </div>
+  )
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,137 @@
+import { useUiStore } from '../../store/useUiStore'
+import { useAuthStore } from '../../store/useAuthStore'
+import type { ViewMode } from '../../types'
+
+const NAV_ITEMS: { mode: ViewMode; label: string; icon: React.ReactNode }[] = [
+  {
+    mode: 'home',
+    label: '홈',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M3 9.5L12 3l9 6.5V20a1 1 0 01-1 1H4a1 1 0 01-1-1V9.5z" />
+        <path d="M9 21V12h6v9" />
+      </svg>
+    ),
+  },
+  {
+    mode: '2d',
+    label: '그래프',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+        <circle cx="12" cy="12" r="2.5" />
+        <circle cx="4" cy="6" r="2" />
+        <circle cx="20" cy="6" r="2" />
+        <circle cx="4" cy="18" r="2" />
+        <circle cx="20" cy="18" r="2" />
+        <line x1="12" y1="12" x2="4" y2="6" />
+        <line x1="12" y1="12" x2="20" y2="6" />
+        <line x1="12" y1="12" x2="4" y2="18" />
+        <line x1="12" y1="12" x2="20" y2="18" />
+      </svg>
+    ),
+  },
+  {
+    mode: '3d',
+    label: '터널',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <ellipse cx="12" cy="5" rx="9" ry="3" />
+        <path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5" />
+        <path d="M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3" />
+      </svg>
+    ),
+  },
+]
+
+export default function Sidebar() {
+  const { viewMode, setViewMode } = useUiStore()
+  const { user, clearAuth } = useAuthStore()
+
+  const handleLogout = () => {
+    clearAuth()
+    window.location.href = '/login'
+  }
+
+  return (
+    <aside
+      className="flex flex-col items-center py-5 gap-1 flex-shrink-0"
+      style={{
+        width: 64,
+        background: 'rgba(255,255,255,0.02)',
+        borderRight: '1px solid rgba(255,255,255,0.06)',
+      }}
+    >
+      {/* 로고 */}
+      <div className="mb-4">
+        <div
+          className="w-9 h-9 rounded-xl flex items-center justify-center"
+          style={{
+            background: 'linear-gradient(135deg, #7c3aed, #4f46e5)',
+            boxShadow: '0 0 16px rgba(124,58,237,0.4)',
+          }}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+            <circle cx="12" cy="12" r="3" fill="white" />
+            <circle cx="4" cy="6" r="2" fill="white" fillOpacity="0.6" />
+            <circle cx="20" cy="6" r="2" fill="white" fillOpacity="0.6" />
+            <circle cx="4" cy="18" r="2" fill="white" fillOpacity="0.6" />
+            <circle cx="20" cy="18" r="2" fill="white" fillOpacity="0.6" />
+            <line x1="12" y1="12" x2="4" y2="6" stroke="white" strokeOpacity="0.5" strokeWidth="1.5" />
+            <line x1="12" y1="12" x2="20" y2="6" stroke="white" strokeOpacity="0.5" strokeWidth="1.5" />
+            <line x1="12" y1="12" x2="4" y2="18" stroke="white" strokeOpacity="0.5" strokeWidth="1.5" />
+            <line x1="12" y1="12" x2="20" y2="18" stroke="white" strokeOpacity="0.5" strokeWidth="1.5" />
+          </svg>
+        </div>
+      </div>
+
+      {/* 네비게이션 */}
+      <nav className="flex flex-col items-center gap-1 flex-1">
+        {NAV_ITEMS.map(({ mode, label, icon }) => {
+          const active = viewMode === mode
+          return (
+            <button
+              key={mode}
+              onClick={() => setViewMode(mode)}
+              title={label}
+              className="relative w-10 h-10 rounded-xl flex items-center justify-center transition-all duration-150 cursor-pointer group"
+              style={{
+                background: active ? 'rgba(167,139,250,0.15)' : 'transparent',
+                color: active ? '#a78bfa' : '#6b6880',
+              }}
+              onMouseEnter={(e) => {
+                if (!active) e.currentTarget.style.background = 'rgba(255,255,255,0.06)'
+              }}
+              onMouseLeave={(e) => {
+                if (!active) e.currentTarget.style.background = 'transparent'
+              }}
+            >
+              {active && (
+                <span
+                  className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 rounded-r-full"
+                  style={{ background: '#a78bfa' }}
+                />
+              )}
+              {icon}
+            </button>
+          )
+        })}
+      </nav>
+
+      {/* 프로필 / 로그아웃 */}
+      <button
+        onClick={handleLogout}
+        title={user?.email ?? '로그아웃'}
+        className="w-8 h-8 rounded-full overflow-hidden flex items-center justify-center transition-all duration-150 cursor-pointer mt-2"
+        style={{ background: 'rgba(255,255,255,0.08)', color: '#9b97b2' }}
+        onMouseEnter={(e) => { e.currentTarget.style.color = '#f87171' }}
+        onMouseLeave={(e) => { e.currentTarget.style.color = '#9b97b2' }}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+          <path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4" />
+          <polyline points="16 17 21 12 16 7" />
+          <line x1="21" y1="12" x2="9" y2="12" />
+        </svg>
+      </button>
+    </aside>
+  )
+}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react'
+
+interface ToastProps {
+  message: string
+  type: 'error' | 'info'
+  onClose: () => void
+  duration?: number
+}
+
+export default function Toast({ message, type, onClose, duration = 3000 }: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(onClose, duration)
+    return () => clearTimeout(timer)
+  }, [onClose, duration])
+
+  const isError = type === 'error'
+
+  return (
+    <div
+      className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2.5 px-4 py-3 rounded-xl text-sm font-medium"
+      style={{
+        background: isError ? 'rgba(239,68,68,0.15)' : 'rgba(167,139,250,0.15)',
+        border: isError ? '1px solid rgba(239,68,68,0.3)' : '1px solid rgba(167,139,250,0.3)',
+        color: isError ? '#fca5a5' : '#c4b5fd',
+        backdropFilter: 'blur(12px)',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+        animation: 'fadeInUp 0.2s ease',
+      }}
+    >
+      {isError ? (
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+      ) : (
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+      )}
+      {message}
+      <button onClick={onClose} className="ml-1 opacity-60 hover:opacity-100 cursor-pointer">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -11,7 +11,7 @@ export function useAuth(onError?: (msg: string) => void) {
       // fetchMe에 토큰을 직접 전달 → setAuth 전에도 인증 헤더 포함
       const me = await fetchMe(auth.access_token)
       setAuth(auth.access_token, me)
-      window.location.href = '/app'
+      // 상태 업데이트 후 LoginPage 컴포넌트가 자동으로 재렌더링되며 /app으로 라우팅됩니다.
     } catch (e) {
       console.error('로그인 실패', e)
       onError?.('로그인에 실패했어요. 다시 시도해주세요.')

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -8,7 +8,8 @@ export function useAuth(onError?: (msg: string) => void) {
   const handleCredential = async (credential: string) => {
     try {
       const auth = await loginWithGoogle(credential)
-      const me = await fetchMe()
+      // fetchMe에 토큰을 직접 전달 → setAuth 전에도 인증 헤더 포함
+      const me = await fetchMe(auth.access_token)
       setAuth(auth.access_token, me)
       window.location.href = '/app'
     } catch (e) {

--- a/src/index.css
+++ b/src/index.css
@@ -42,3 +42,14 @@
     border-radius: 2px;
   }
 }
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 8px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- **AppLayout**: 좌측 64px 사이드바 + 메인 영역, 홈/2D/3D 뷰 전환
- **Sidebar**: 아이콘 네비게이션 (홈·그래프·터널), 활성 탭 보라색 인디케이터, 하단 로그아웃
- **HomeView**: ChatGPT 스타일 중앙 입력창, 사용자 이름 인사말, 예시 제안 칩
- **MemoInput**: 자동 높이 textarea, Enter 전송 / Shift+Enter 줄바꿈, 로딩 스피너, 전송 후 2D 뷰 자동 전환
- **Toast**: 409 중복 메모 / 에러 알림, 3초 자동 닫힘, fadeInUp 애니메이션

## 테스트 방법
1. `npm run dev` 후 로그인 → `/app` 진입
2. 홈 화면에 중앙 입력창 + 인사말 확인
3. 사이드바 아이콘 클릭 시 뷰 전환 확인 (그래프/터널은 placeholder)
4. 메모 입력 후 Enter → 로딩 스피너 → 2D 뷰로 전환 확인 (백엔드 연결 필요)
5. 로그아웃 버튼 클릭 → `/login`으로 이동 확인

Closes #3