### PR TITLE
feat: 2D 그래프 뷰 구현

### DIFF
--- a/src/components/graph/GraphView.tsx
+++ b/src/components/graph/GraphView.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect } from 'react'
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  useNodesState,
+  useEdgesState,
+  BackgroundVariant,
+  type NodeMouseHandler,
+  type Node as RFNode,
+  type Edge as RFEdge,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import { useGraph } from '../../hooks/useGraph'
+import { useUiStore } from '../../store/useUiStore'
+import MemoNode from './MemoNode'
+import NodeDetailPanel from './NodeDetailPanel'
+
+const nodeTypes = { memo: MemoNode }
+
+// 황금각(golden angle) 기반 phyllotaxis 레이아웃 — 자연스럽게 퍼짐
+function computePositions(count: number): Array<{ x: number; y: number }> {
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5))
+  return Array.from({ length: count }, (_, i) => {
+    const radius = i === 0 ? 0 : 150 * Math.sqrt(i)
+    const angle = i * goldenAngle
+    return {
+      x: radius * Math.cos(angle),
+      y: radius * Math.sin(angle),
+    }
+  })
+}
+
+export default function GraphView() {
+  const { data, isLoading, isError } = useGraph()
+  const { selectedNodeId, selectNode, closePanel } = useUiStore()
+
+  const [rfNodes, setRfNodes, onNodesChange] = useNodesState<RFNode>([])
+  const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState<RFEdge>([])
+
+  useEffect(() => {
+    if (!data) return
+
+    const positions = computePositions(data.nodes.length)
+
+    setRfNodes(
+      data.nodes.map((node, i) => ({
+        id: node.node_id,
+        type: 'memo',
+        position: positions[i],
+        data: node as unknown as Record<string, unknown>,
+        selected: node.node_id === selectedNodeId,
+      }))
+    )
+
+    setRfEdges(
+      data.edges.map((edge) => ({
+        id: edge.edge_id,
+        source: edge.source_node_id,
+        target: edge.target_node_id,
+        style: {
+          stroke: `rgba(167,139,250,${0.15 + edge.similarity_score * 0.5})`,
+          strokeWidth: 1 + edge.similarity_score * 1.5,
+        },
+        animated: edge.similarity_score > 0.7,
+      }))
+    )
+  }, [data, selectedNodeId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleNodeClick: NodeMouseHandler = useCallback(
+    (_event, node) => {
+      selectNode(node.id)
+    },
+    [selectNode]
+  )
+
+  if (isLoading) {
+    return (
+      <div
+        className="flex-1 flex items-center justify-center flex-col gap-3"
+        style={{ color: '#9b97b2' }}
+      >
+        <svg
+          className="animate-spin"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" strokeOpacity="0.3" />
+          <path d="M21 12a9 9 0 00-9-9" />
+        </svg>
+        <span className="text-sm">그래프 불러오는 중...</span>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex-1 flex items-center justify-center" style={{ color: '#9b97b2' }}>
+        <p className="text-sm">그래프를 불러오지 못했어요.</p>
+      </div>
+    )
+  }
+
+  if (!data || data.nodes.length === 0) {
+    return (
+      <div
+        className="flex-1 flex items-center justify-center flex-col gap-3"
+        style={{ color: '#6b6880' }}
+      >
+        <svg
+          width="44"
+          height="44"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.2"
+          strokeOpacity="0.35"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <circle cx="4" cy="6" r="2" />
+          <circle cx="20" cy="6" r="2" />
+          <circle cx="4" cy="18" r="2" />
+          <circle cx="20" cy="18" r="2" />
+          <line x1="12" y1="12" x2="4" y2="6" />
+          <line x1="12" y1="12" x2="20" y2="6" />
+          <line x1="12" y1="12" x2="4" y2="18" />
+          <line x1="12" y1="12" x2="20" y2="18" />
+        </svg>
+        <div className="text-center">
+          <p className="text-sm font-medium" style={{ color: '#9b97b2' }}>
+            아직 메모가 없어요
+          </p>
+          <p className="text-xs mt-1">홈으로 돌아가 첫 메모를 작성해보세요</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 relative overflow-hidden">
+      <ReactFlow
+        nodes={rfNodes}
+        edges={rfEdges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeClick={handleNodeClick}
+        onPaneClick={closePanel}
+        nodeTypes={nodeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.3 }}
+        minZoom={0.2}
+        maxZoom={2}
+        proOptions={{ hideAttribution: true }}
+        style={{ background: 'transparent' }}
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={32}
+          size={1}
+          color="rgba(255,255,255,0.04)"
+        />
+        <Controls
+          style={{
+            background: 'rgba(255,255,255,0.05)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            borderRadius: 8,
+          }}
+        />
+      </ReactFlow>
+
+      {selectedNodeId && data && (
+        <NodeDetailPanel
+          node={data.nodes.find((n) => n.node_id === selectedNodeId) ?? null}
+          onClose={closePanel}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/graph/MemoNode.tsx
+++ b/src/components/graph/MemoNode.tsx
@@ -1,0 +1,89 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+import type { Node as MemoData } from '../../types'
+
+export default function MemoNode({ data: rawData, selected }: NodeProps) {
+  const data = rawData as unknown as MemoData
+  return (
+    <>
+      <Handle
+        type="target"
+        position={Position.Top}
+        style={{ opacity: 0, pointerEvents: 'none' }}
+      />
+
+      <div
+        style={{
+          background: selected
+            ? 'rgba(167,139,250,0.1)'
+            : 'rgba(255,255,255,0.04)',
+          border: `1.5px solid ${selected ? '#a78bfa' : data.category_color + '99'}`,
+          borderRadius: 12,
+          padding: '10px 14px',
+          minWidth: 150,
+          maxWidth: 210,
+          backdropFilter: 'blur(8px)',
+          boxShadow: selected
+            ? '0 0 20px rgba(167,139,250,0.25)'
+            : `0 0 10px ${data.category_color}22`,
+          transition: 'all 0.15s ease',
+          cursor: 'pointer',
+        }}
+      >
+        {/* 카테고리 컬러 인디케이터 */}
+        <div
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            background: data.category_color,
+            marginBottom: 8,
+            boxShadow: `0 0 6px ${data.category_color}88`,
+          }}
+        />
+
+        {/* 요약 텍스트 */}
+        <p
+          style={{
+            color: '#f1f0f5',
+            fontSize: 12,
+            lineHeight: 1.6,
+            margin: 0,
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {data.summary}
+        </p>
+
+        {/* 키워드 */}
+        {data.keywords.length > 0 && (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 8 }}>
+            {data.keywords.slice(0, 3).map((kw) => (
+              <span
+                key={kw}
+                style={{
+                  fontSize: 10,
+                  padding: '1px 7px',
+                  borderRadius: 20,
+                  background: `${data.category_color}18`,
+                  color: data.category_color,
+                  border: `1px solid ${data.category_color}40`,
+                }}
+              >
+                {kw}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        style={{ opacity: 0, pointerEvents: 'none' }}
+      />
+    </>
+  )
+}

--- a/src/components/graph/NodeDetailPanel.tsx
+++ b/src/components/graph/NodeDetailPanel.tsx
@@ -1,0 +1,185 @@
+import { useState } from 'react'
+import type { Node } from '../../types'
+import { useDeleteNode } from '../../hooks/useDeleteNode'
+import { useUiStore } from '../../store/useUiStore'
+
+interface NodeDetailPanelProps {
+  node: Node | null
+  onClose: () => void
+}
+
+export default function NodeDetailPanel({ node, onClose }: NodeDetailPanelProps) {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const { mutate: deleteNode, isPending } = useDeleteNode()
+  const closePanel = useUiStore((s) => s.closePanel)
+
+  if (!node) return null
+
+  const handleDelete = () => {
+    if (!confirmDelete) {
+      setConfirmDelete(true)
+      return
+    }
+    deleteNode(node.node_id, {
+      onSuccess: () => closePanel(),
+    })
+  }
+
+  const formattedDate = new Date(node.created_at).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        width: 320,
+        height: '100%',
+        background: 'rgba(10,8,20,0.85)',
+        backdropFilter: 'blur(20px)',
+        borderLeft: '1px solid rgba(255,255,255,0.08)',
+        display: 'flex',
+        flexDirection: 'column',
+        zIndex: 10,
+        animation: 'slideInRight 0.2s ease',
+      }}
+    >
+      {/* 헤더 */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '16px 20px',
+          borderBottom: '1px solid rgba(255,255,255,0.06)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <div
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              background: node.category_color,
+              boxShadow: `0 0 8px ${node.category_color}88`,
+            }}
+          />
+          <span style={{ color: '#9b97b2', fontSize: 12 }}>메모 상세</span>
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#6b6880',
+            cursor: 'pointer',
+            padding: 4,
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+
+      {/* 내용 */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '20px' }}>
+        {/* 키워드 */}
+        {node.keywords.length > 0 && (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 16 }}>
+            {node.keywords.map((kw) => (
+              <span
+                key={kw}
+                style={{
+                  fontSize: 11,
+                  padding: '3px 10px',
+                  borderRadius: 20,
+                  background: `${node.category_color}18`,
+                  color: node.category_color,
+                  border: `1px solid ${node.category_color}40`,
+                }}
+              >
+                {kw}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* AI 요약 */}
+        <div style={{ marginBottom: 20 }}>
+          <p style={{ color: '#6b6880', fontSize: 11, marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+            AI 요약
+          </p>
+          <p style={{ color: '#c4b5fd', fontSize: 13, lineHeight: 1.7, margin: 0 }}>
+            {node.summary}
+          </p>
+        </div>
+
+        {/* 구분선 */}
+        <div style={{ height: 1, background: 'rgba(255,255,255,0.06)', marginBottom: 20 }} />
+
+        {/* 원본 메모 */}
+        <div style={{ marginBottom: 20 }}>
+          <p style={{ color: '#6b6880', fontSize: 11, marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+            원본 메모
+          </p>
+          <p style={{ color: '#f1f0f5', fontSize: 13, lineHeight: 1.8, margin: 0, whiteSpace: 'pre-wrap' }}>
+            {node.original_text}
+          </p>
+        </div>
+
+        {/* 날짜 */}
+        <p style={{ color: '#4b4860', fontSize: 11 }}>{formattedDate}</p>
+      </div>
+
+      {/* 하단 삭제 버튼 */}
+      <div style={{ padding: '16px 20px', borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+        <button
+          onClick={handleDelete}
+          disabled={isPending}
+          style={{
+            width: '100%',
+            padding: '10px',
+            borderRadius: 10,
+            border: confirmDelete
+              ? '1px solid rgba(239,68,68,0.5)'
+              : '1px solid rgba(255,255,255,0.08)',
+            background: confirmDelete
+              ? 'rgba(239,68,68,0.12)'
+              : 'rgba(255,255,255,0.04)',
+            color: confirmDelete ? '#f87171' : '#6b6880',
+            fontSize: 13,
+            cursor: isPending ? 'default' : 'pointer',
+            transition: 'all 0.15s ease',
+          }}
+        >
+          {isPending ? '삭제 중...' : confirmDelete ? '정말 삭제할까요? 다시 클릭하세요' : '메모 삭제'}
+        </button>
+        {confirmDelete && !isPending && (
+          <button
+            onClick={() => setConfirmDelete(false)}
+            style={{
+              width: '100%',
+              marginTop: 6,
+              padding: '6px',
+              background: 'none',
+              border: 'none',
+              color: '#6b6880',
+              fontSize: 12,
+              cursor: 'pointer',
+            }}
+          >
+            취소
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,18 +1,7 @@
 import { useUiStore } from '../../store/useUiStore'
 import Sidebar from './Sidebar'
 import HomeView from '../home/HomeView'
-
-// Phase 4/5에서 구현 예정
-function GraphView() {
-  return (
-    <div className="flex-1 flex items-center justify-center" style={{ color: '#6b6880' }}>
-      <div className="text-center flex flex-col gap-2">
-        <span className="text-4xl">🕸</span>
-        <p className="text-sm">2D 그래프 뷰 — Phase 4에서 구현 예정</p>
-      </div>
-    </div>
-  )
-}
+import GraphView from '../graph/GraphView'
 
 function TunnelView() {
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,17 @@
   }
 }
 
+@keyframes slideInRight {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 @keyframes fadeInUp {
   from {
     opacity: 0;


### PR DESCRIPTION
## Summary
- `GraphView`: `@xyflow/react` 기반 그래프 렌더링, 황금각(phyllotaxis) 자동 레이아웃
- `MemoNode`: 카테고리 컬러 인디케이터, AI 요약, 키워드 칩 표시하는 커스텀 노드
- `NodeDetailPanel`: 노드 클릭 시 우측 슬라이드 패널 — 원본 메모/AI 요약/키워드/삭제 지원
- `AppLayout`: GraphView placeholder → 실제 구현으로 교체

## Test plan
- [ ] 로그인 후 메모 1개 이상 작성
- [ ] 사이드바에서 2D 뷰 아이콘 클릭 → 그래프 렌더링 확인
- [ ] 노드 클릭 → 우측 상세 패널 슬라이드 인 확인
- [ ] 패널에서 원본/요약/키워드 표시 확인
- [ ] 메모 삭제 (2번 클릭 확인 후 삭제) → 그래프 갱신 확인
- [ ] 빈 상태 (메모 없을 때) 안내 화면 확인