### PR TITLE
feat: 3D 터널 뷰 구현

### DIFF
--- a/src/components/graph/TunnelView.tsx
+++ b/src/components/graph/TunnelView.tsx
@@ -180,7 +180,7 @@ export default function TunnelView() {
   const { data, isLoading, isError } = useGraph()
   const { selectedNodeId, selectNode, closePanel } = useUiStore()
   const containerRef = useRef<HTMLDivElement>(null)
-  const [containerWidth, setContainerWidth] = useState(900)
+  const [containerWidth, setContainerWidth] = useState(() => Math.max(600, window.innerWidth - 64))
 
   // 컨테이너 너비 감지
   useEffect(() => {

--- a/src/components/graph/TunnelView.tsx
+++ b/src/components/graph/TunnelView.tsx
@@ -7,107 +7,108 @@ import { useUiStore } from '../../store/useUiStore'
 import NodeDetailPanel from './NodeDetailPanel'
 import type { Node as MemoData } from '../../types'
 
-const Z_SPACING = 5
-const START_Z = 8
+const Z_SPACING = 6   // 노드 간 Z 간격
+const START_Z = 10    // 카메라 초기 Z
 
-// 오래된 노드일수록 Z 음수 방향으로 배치 (터널 안쪽)
+// 최신 노드 = Z 가까이, 오래된 노드 = Z 깊숙이
 function buildPositions(nodes: MemoData[]): Map<string, THREE.Vector3> {
   const sorted = [...nodes].sort(
-    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    // 최신순 정렬: index 0이 가장 최신 → z=0 (카메라에 가장 가까움)
   )
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5)) // 2.4rad
   const map = new Map<string, THREE.Vector3>()
   sorted.forEach((node, i) => {
     const z = -(i * Z_SPACING)
-    const angle = i * 2.4 // ~황금각 (radians)
-    const r = 1.8 + (i % 2) * 1.2
+    const r = Math.min(4, 0.5 + i * 0.5) // 반지름을 서서히 키우되 최대 4 제한
+    const angle = i * goldenAngle
     map.set(
       node.node_id,
-      new THREE.Vector3(r * Math.cos(angle), r * Math.sin(angle) * 0.55, z)
+      new THREE.Vector3(r * Math.cos(angle), r * Math.sin(angle) * 0.6, z)
     )
   })
   return map
 }
 
-// ─── 노드 구체 ────────────────────────────────────────────────────────────────
+// ─── 카드 노드 ───────────────────────────────────────────────────────────────
 
-interface MemoSphereProps {
+interface MemoCardProps {
   node: MemoData
   position: THREE.Vector3
   selected: boolean
   onClick: () => void
 }
 
-function MemoSphere({ node, position, selected, onClick }: MemoSphereProps) {
-  const meshRef = useRef<THREE.Mesh>(null)
-
-  useFrame(() => {
-    if (!meshRef.current) return
-    const s = 1 + Math.sin(Date.now() * 0.002 + position.z * 0.3) * 0.04
-    meshRef.current.scale.setScalar(selected ? s * 1.35 : s)
-  })
-
+function MemoCard({ node, position, selected, onClick }: MemoCardProps) {
   return (
-    <group position={position}>
-      {/* 메인 구체 */}
-      <mesh ref={meshRef} onClick={(e) => { e.stopPropagation(); onClick() }}>
-        <sphereGeometry args={[0.35, 24, 24]} />
-        <meshStandardMaterial
-          color={node.category_color}
-          emissive={node.category_color}
-          emissiveIntensity={selected ? 2 : 0.6}
-          roughness={0.3}
-          metalness={0.1}
-          transparent
-          opacity={0.9}
+    <Html center distanceFactor={9} position={position} style={{ width: 210 }}>
+      <div
+        onClick={(e) => { e.stopPropagation(); onClick() }}
+        style={{
+          width: 210,
+          background: selected ? 'rgba(167,139,250,0.1)' : 'rgba(14,12,28,0.75)',
+          border: `1.5px solid ${selected ? '#a78bfa' : node.category_color + '88'}`,
+          borderRadius: 12,
+          padding: '10px 14px',
+          backdropFilter: 'blur(12px)',
+          boxShadow: selected
+            ? '0 0 24px rgba(167,139,250,0.3), 0 4px 24px rgba(0,0,0,0.5)'
+            : `0 0 12px ${node.category_color}22, 0 4px 20px rgba(0,0,0,0.4)`,
+          cursor: 'pointer',
+          fontFamily: "'Pretendard', 'Inter', sans-serif",
+          transition: 'border-color 0.15s, box-shadow 0.15s',
+        }}
+      >
+        {/* 카테고리 컬러 인디케이터 */}
+        <div
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            background: node.category_color,
+            boxShadow: `0 0 6px ${node.category_color}88`,
+            marginBottom: 8,
+          }}
         />
-      </mesh>
 
-      {/* 글로우 헤일로 */}
-      <mesh>
-        <sphereGeometry args={[0.58, 16, 16]} />
-        <meshBasicMaterial
-          color={node.category_color}
-          transparent
-          opacity={selected ? 0.15 : 0.07}
-          side={THREE.BackSide}
-        />
-      </mesh>
-
-      {/* 선택 시 링 */}
-      {selected && (
-        <mesh>
-          <ringGeometry args={[0.48, 0.58, 32]} />
-          <meshBasicMaterial
-            color="#a78bfa"
-            transparent
-            opacity={0.75}
-            side={THREE.DoubleSide}
-          />
-        </mesh>
-      )}
-
-      {/* 키워드 레이블 */}
-      {node.keywords[0] && (
-        <Html
-          center
-          distanceFactor={12}
-          position={[0, 0.68, 0]}
-          style={{ pointerEvents: 'none', userSelect: 'none' }}
+        {/* 요약 */}
+        <p
+          style={{
+            color: '#f1f0f5',
+            fontSize: 12,
+            lineHeight: 1.65,
+            margin: 0,
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
         >
-          <span
-            style={{
-              color: '#c4b5fd',
-              fontSize: 11,
-              fontFamily: "'Pretendard', 'Inter', sans-serif",
-              whiteSpace: 'nowrap',
-              textShadow: '0 0 8px rgba(196,181,253,0.6)',
-            }}
-          >
-            {node.keywords[0]}
-          </span>
-        </Html>
-      )}
-    </group>
+          {node.summary}
+        </p>
+
+        {/* 키워드 */}
+        {node.keywords.length > 0 && (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 8 }}>
+            {node.keywords.slice(0, 3).map((kw) => (
+              <span
+                key={kw}
+                style={{
+                  fontSize: 10,
+                  padding: '1px 7px',
+                  borderRadius: 20,
+                  background: `${node.category_color}18`,
+                  color: node.category_color,
+                  border: `1px solid ${node.category_color}40`,
+                }}
+              >
+                {kw}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </Html>
   )
 }
 
@@ -116,14 +117,15 @@ function MemoSphere({ node, position, selected, onClick }: MemoSphereProps) {
 function CameraController({ nodeCount }: { nodeCount: number }) {
   const { camera } = useThree()
   const targetZ = useRef(START_Z)
-  const minZ = -(nodeCount - 1) * Z_SPACING - 6
+  const minZ = -(nodeCount - 1) * Z_SPACING - 8
 
   useEffect(() => {
     const handleWheel = (e: WheelEvent) => {
       e.preventDefault()
+      // 아래로 스크롤 → 과거로 이동 (Z 감소)
       targetZ.current = Math.max(
         minZ,
-        Math.min(START_Z, targetZ.current - e.deltaY * 0.025)
+        Math.min(START_Z, targetZ.current - e.deltaY * 0.03)
       )
     }
     window.addEventListener('wheel', handleWheel, { passive: false })
@@ -131,17 +133,22 @@ function CameraController({ nodeCount }: { nodeCount: number }) {
   }, [minZ])
 
   useFrame(() => {
-    camera.position.z += (targetZ.current - camera.position.z) * 0.1
+    camera.position.z += (targetZ.current - camera.position.z) * 0.09
   })
 
   return null
 }
 
-// ─── 씬 내부 ─────────────────────────────────────────────────────────────────
+// ─── 씬 ──────────────────────────────────────────────────────────────────────
 
 interface SceneProps {
   nodes: MemoData[]
-  edges: { edge_id: string; source_node_id: string; target_node_id: string; similarity_score: number }[]
+  edges: {
+    edge_id: string
+    source_node_id: string
+    target_node_id: string
+    similarity_score: number
+  }[]
   selectedNodeId: string | null
   onNodeClick: (id: string) => void
   onPaneClick: () => void
@@ -149,26 +156,10 @@ interface SceneProps {
 
 function Scene({ nodes, edges, selectedNodeId, onNodeClick, onPaneClick }: SceneProps) {
   const positions = useMemo(() => buildPositions(nodes), [nodes])
-  const ringCount = Math.ceil(nodes.length * 1.5) + 4
 
   return (
     <>
-      <ambientLight intensity={0.25} />
-      <pointLight position={[0, 0, START_Z]} intensity={3} color="#a78bfa" distance={30} />
-
-      {/* 터널 링 장식 */}
-      {Array.from({ length: ringCount }, (_, i) => (
-        <mesh
-          key={`ring-${i}`}
-          position={[0, 0, -(i * Z_SPACING * 0.72)]}
-          rotation={[Math.PI / 2, 0, 0]}
-        >
-          <torusGeometry args={[3.8, 0.012, 8, 72]} />
-          <meshBasicMaterial color="#a78bfa" transparent opacity={0.05} />
-        </mesh>
-      ))}
-
-      {/* 엣지 */}
+      {/* 엣지 (카드 뒤에 렌더링됨) */}
       {edges.map((edge) => {
         const from = positions.get(edge.source_node_id)
         const to = positions.get(edge.target_node_id)
@@ -176,21 +167,24 @@ function Scene({ nodes, edges, selectedNodeId, onNodeClick, onPaneClick }: Scene
         return (
           <Line
             key={edge.edge_id}
-            points={[from.toArray() as [number, number, number], to.toArray() as [number, number, number]]}
+            points={[
+              from.toArray() as [number, number, number],
+              to.toArray() as [number, number, number],
+            ]}
             color="#a78bfa"
-            lineWidth={0.5 + edge.similarity_score * 1.5}
-            opacity={0.12 + edge.similarity_score * 0.3}
+            lineWidth={0.4 + edge.similarity_score * 1.2}
+            opacity={0.1 + edge.similarity_score * 0.28}
             transparent
           />
         )
       })}
 
-      {/* 노드 */}
+      {/* 카드 노드 */}
       {nodes.map((node) => {
         const pos = positions.get(node.node_id)
         if (!pos) return null
         return (
-          <MemoSphere
+          <MemoCard
             key={node.node_id}
             node={node}
             position={pos}
@@ -200,13 +194,9 @@ function Scene({ nodes, edges, selectedNodeId, onNodeClick, onPaneClick }: Scene
         )
       })}
 
-      {/* 배경 클릭 시 패널 닫기 */}
-      <mesh
-        position={[0, 0, -999]}
-        onClick={onPaneClick}
-        visible={false}
-      >
-        <planeGeometry args={[9999, 9999]} />
+      {/* 배경 클릭 → 패널 닫기 */}
+      <mesh position={[0, 0, -9999]} onClick={onPaneClick} visible={false}>
+        <planeGeometry args={[99999, 99999]} />
         <meshBasicMaterial />
       </mesh>
 
@@ -215,7 +205,7 @@ function Scene({ nodes, edges, selectedNodeId, onNodeClick, onPaneClick }: Scene
   )
 }
 
-// ─── 메인 TunnelView ──────────────────────────────────────────────────────────
+// ─── 메인 ────────────────────────────────────────────────────────────────────
 
 export default function TunnelView() {
   const { data, isLoading, isError } = useGraph()
@@ -223,12 +213,23 @@ export default function TunnelView() {
 
   if (isLoading) {
     return (
-      <div className="flex-1 flex items-center justify-center flex-col gap-3" style={{ color: '#9b97b2' }}>
-        <svg className="animate-spin" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <div
+        className="flex-1 flex items-center justify-center flex-col gap-3"
+        style={{ color: '#9b97b2' }}
+      >
+        <svg
+          className="animate-spin"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
           <path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" strokeOpacity="0.3" />
           <path d="M21 12a9 9 0 00-9-9" />
         </svg>
-        <span className="text-sm">터널 불러오는 중...</span>
+        <span className="text-sm">불러오는 중...</span>
       </div>
     )
   }
@@ -243,13 +244,14 @@ export default function TunnelView() {
 
   if (!data || data.nodes.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center flex-col gap-3" style={{ color: '#6b6880' }}>
-        <svg width="44" height="44" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.2" strokeOpacity="0.35">
-          <circle cx="12" cy="12" r="3" />
-          <path d="M12 3a9 9 0 000 18A9 9 0 0012 3" strokeDasharray="3 2" />
-        </svg>
+      <div
+        className="flex-1 flex items-center justify-center flex-col gap-3"
+        style={{ color: '#6b6880' }}
+      >
         <div className="text-center">
-          <p className="text-sm font-medium" style={{ color: '#9b97b2' }}>아직 메모가 없어요</p>
+          <p className="text-sm font-medium" style={{ color: '#9b97b2' }}>
+            아직 메모가 없어요
+          </p>
           <p className="text-xs mt-1">홈으로 돌아가 첫 메모를 작성해보세요</p>
         </div>
       </div>
@@ -259,11 +261,10 @@ export default function TunnelView() {
   return (
     <div className="flex-1 relative overflow-hidden">
       <Canvas
-        camera={{ position: [0, 0, START_Z], fov: 60 }}
-        style={{ background: '#07070f' }}
+        camera={{ position: [0, 0, START_Z], fov: 55 }}
+        style={{ background: 'radial-gradient(ellipse at 50% 40%, #120a2a 0%, #07070f 70%)' }}
         gl={{ antialias: true, alpha: false }}
       >
-        <fog attach="fog" args={['#07070f', 20, 60]} />
         <Scene
           nodes={data.nodes}
           edges={data.edges}
@@ -288,10 +289,17 @@ export default function TunnelView() {
           gap: 6,
         }}
       >
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
           <path d="M12 5v14M5 12l7 7 7-7" />
         </svg>
-        스크롤하여 시간축 탐색
+        스크롤 — 과거 메모로 이동
       </div>
 
       {/* 노드 상세 패널 */}

--- a/src/components/graph/TunnelView.tsx
+++ b/src/components/graph/TunnelView.tsx
@@ -1,0 +1,306 @@
+import { useRef, useEffect, useMemo } from 'react'
+import { Canvas, useThree, useFrame } from '@react-three/fiber'
+import { Html, Line } from '@react-three/drei'
+import * as THREE from 'three'
+import { useGraph } from '../../hooks/useGraph'
+import { useUiStore } from '../../store/useUiStore'
+import NodeDetailPanel from './NodeDetailPanel'
+import type { Node as MemoData } from '../../types'
+
+const Z_SPACING = 5
+const START_Z = 8
+
+// 오래된 노드일수록 Z 음수 방향으로 배치 (터널 안쪽)
+function buildPositions(nodes: MemoData[]): Map<string, THREE.Vector3> {
+  const sorted = [...nodes].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  )
+  const map = new Map<string, THREE.Vector3>()
+  sorted.forEach((node, i) => {
+    const z = -(i * Z_SPACING)
+    const angle = i * 2.4 // ~황금각 (radians)
+    const r = 1.8 + (i % 2) * 1.2
+    map.set(
+      node.node_id,
+      new THREE.Vector3(r * Math.cos(angle), r * Math.sin(angle) * 0.55, z)
+    )
+  })
+  return map
+}
+
+// ─── 노드 구체 ────────────────────────────────────────────────────────────────
+
+interface MemoSphereProps {
+  node: MemoData
+  position: THREE.Vector3
+  selected: boolean
+  onClick: () => void
+}
+
+function MemoSphere({ node, position, selected, onClick }: MemoSphereProps) {
+  const meshRef = useRef<THREE.Mesh>(null)
+
+  useFrame(() => {
+    if (!meshRef.current) return
+    const s = 1 + Math.sin(Date.now() * 0.002 + position.z * 0.3) * 0.04
+    meshRef.current.scale.setScalar(selected ? s * 1.35 : s)
+  })
+
+  return (
+    <group position={position}>
+      {/* 메인 구체 */}
+      <mesh ref={meshRef} onClick={(e) => { e.stopPropagation(); onClick() }}>
+        <sphereGeometry args={[0.35, 24, 24]} />
+        <meshStandardMaterial
+          color={node.category_color}
+          emissive={node.category_color}
+          emissiveIntensity={selected ? 2 : 0.6}
+          roughness={0.3}
+          metalness={0.1}
+          transparent
+          opacity={0.9}
+        />
+      </mesh>
+
+      {/* 글로우 헤일로 */}
+      <mesh>
+        <sphereGeometry args={[0.58, 16, 16]} />
+        <meshBasicMaterial
+          color={node.category_color}
+          transparent
+          opacity={selected ? 0.15 : 0.07}
+          side={THREE.BackSide}
+        />
+      </mesh>
+
+      {/* 선택 시 링 */}
+      {selected && (
+        <mesh>
+          <ringGeometry args={[0.48, 0.58, 32]} />
+          <meshBasicMaterial
+            color="#a78bfa"
+            transparent
+            opacity={0.75}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      )}
+
+      {/* 키워드 레이블 */}
+      {node.keywords[0] && (
+        <Html
+          center
+          distanceFactor={12}
+          position={[0, 0.68, 0]}
+          style={{ pointerEvents: 'none', userSelect: 'none' }}
+        >
+          <span
+            style={{
+              color: '#c4b5fd',
+              fontSize: 11,
+              fontFamily: "'Pretendard', 'Inter', sans-serif",
+              whiteSpace: 'nowrap',
+              textShadow: '0 0 8px rgba(196,181,253,0.6)',
+            }}
+          >
+            {node.keywords[0]}
+          </span>
+        </Html>
+      )}
+    </group>
+  )
+}
+
+// ─── 카메라 스크롤 컨트롤러 ─────────────────────────────────────────────────
+
+function CameraController({ nodeCount }: { nodeCount: number }) {
+  const { camera } = useThree()
+  const targetZ = useRef(START_Z)
+  const minZ = -(nodeCount - 1) * Z_SPACING - 6
+
+  useEffect(() => {
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      targetZ.current = Math.max(
+        minZ,
+        Math.min(START_Z, targetZ.current - e.deltaY * 0.025)
+      )
+    }
+    window.addEventListener('wheel', handleWheel, { passive: false })
+    return () => window.removeEventListener('wheel', handleWheel)
+  }, [minZ])
+
+  useFrame(() => {
+    camera.position.z += (targetZ.current - camera.position.z) * 0.1
+  })
+
+  return null
+}
+
+// ─── 씬 내부 ─────────────────────────────────────────────────────────────────
+
+interface SceneProps {
+  nodes: MemoData[]
+  edges: { edge_id: string; source_node_id: string; target_node_id: string; similarity_score: number }[]
+  selectedNodeId: string | null
+  onNodeClick: (id: string) => void
+  onPaneClick: () => void
+}
+
+function Scene({ nodes, edges, selectedNodeId, onNodeClick, onPaneClick }: SceneProps) {
+  const positions = useMemo(() => buildPositions(nodes), [nodes])
+  const ringCount = Math.ceil(nodes.length * 1.5) + 4
+
+  return (
+    <>
+      <ambientLight intensity={0.25} />
+      <pointLight position={[0, 0, START_Z]} intensity={3} color="#a78bfa" distance={30} />
+
+      {/* 터널 링 장식 */}
+      {Array.from({ length: ringCount }, (_, i) => (
+        <mesh
+          key={`ring-${i}`}
+          position={[0, 0, -(i * Z_SPACING * 0.72)]}
+          rotation={[Math.PI / 2, 0, 0]}
+        >
+          <torusGeometry args={[3.8, 0.012, 8, 72]} />
+          <meshBasicMaterial color="#a78bfa" transparent opacity={0.05} />
+        </mesh>
+      ))}
+
+      {/* 엣지 */}
+      {edges.map((edge) => {
+        const from = positions.get(edge.source_node_id)
+        const to = positions.get(edge.target_node_id)
+        if (!from || !to) return null
+        return (
+          <Line
+            key={edge.edge_id}
+            points={[from.toArray() as [number, number, number], to.toArray() as [number, number, number]]}
+            color="#a78bfa"
+            lineWidth={0.5 + edge.similarity_score * 1.5}
+            opacity={0.12 + edge.similarity_score * 0.3}
+            transparent
+          />
+        )
+      })}
+
+      {/* 노드 */}
+      {nodes.map((node) => {
+        const pos = positions.get(node.node_id)
+        if (!pos) return null
+        return (
+          <MemoSphere
+            key={node.node_id}
+            node={node}
+            position={pos}
+            selected={node.node_id === selectedNodeId}
+            onClick={() => onNodeClick(node.node_id)}
+          />
+        )
+      })}
+
+      {/* 배경 클릭 시 패널 닫기 */}
+      <mesh
+        position={[0, 0, -999]}
+        onClick={onPaneClick}
+        visible={false}
+      >
+        <planeGeometry args={[9999, 9999]} />
+        <meshBasicMaterial />
+      </mesh>
+
+      <CameraController nodeCount={nodes.length} />
+    </>
+  )
+}
+
+// ─── 메인 TunnelView ──────────────────────────────────────────────────────────
+
+export default function TunnelView() {
+  const { data, isLoading, isError } = useGraph()
+  const { selectedNodeId, selectNode, closePanel } = useUiStore()
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center flex-col gap-3" style={{ color: '#9b97b2' }}>
+        <svg className="animate-spin" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" strokeOpacity="0.3" />
+          <path d="M21 12a9 9 0 00-9-9" />
+        </svg>
+        <span className="text-sm">터널 불러오는 중...</span>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex-1 flex items-center justify-center" style={{ color: '#9b97b2' }}>
+        <p className="text-sm">데이터를 불러오지 못했어요.</p>
+      </div>
+    )
+  }
+
+  if (!data || data.nodes.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center flex-col gap-3" style={{ color: '#6b6880' }}>
+        <svg width="44" height="44" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.2" strokeOpacity="0.35">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M12 3a9 9 0 000 18A9 9 0 0012 3" strokeDasharray="3 2" />
+        </svg>
+        <div className="text-center">
+          <p className="text-sm font-medium" style={{ color: '#9b97b2' }}>아직 메모가 없어요</p>
+          <p className="text-xs mt-1">홈으로 돌아가 첫 메모를 작성해보세요</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 relative overflow-hidden">
+      <Canvas
+        camera={{ position: [0, 0, START_Z], fov: 60 }}
+        style={{ background: '#07070f' }}
+        gl={{ antialias: true, alpha: false }}
+      >
+        <fog attach="fog" args={['#07070f', 20, 60]} />
+        <Scene
+          nodes={data.nodes}
+          edges={data.edges}
+          selectedNodeId={selectedNodeId}
+          onNodeClick={selectNode}
+          onPaneClick={closePanel}
+        />
+      </Canvas>
+
+      {/* 스크롤 힌트 */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 24,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          color: '#4b4860',
+          fontSize: 12,
+          pointerEvents: 'none',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+        }}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M12 5v14M5 12l7 7 7-7" />
+        </svg>
+        스크롤하여 시간축 탐색
+      </div>
+
+      {/* 노드 상세 패널 */}
+      {selectedNodeId && (
+        <NodeDetailPanel
+          node={data.nodes.find((n) => n.node_id === selectedNodeId) ?? null}
+          onClose={closePanel}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/graph/TunnelView.tsx
+++ b/src/components/graph/TunnelView.tsx
@@ -1,207 +1,173 @@
-import { useRef, useEffect, useMemo } from 'react'
-import { Canvas, useThree, useFrame } from '@react-three/fiber'
-import { Html, Line } from '@react-three/drei'
-import * as THREE from 'three'
+import { useRef, useEffect, useState, useMemo } from 'react'
 import { useGraph } from '../../hooks/useGraph'
 import { useUiStore } from '../../store/useUiStore'
 import NodeDetailPanel from './NodeDetailPanel'
 import type { Node as MemoData } from '../../types'
 
-const Z_SPACING = 6   // 노드 간 Z 간격
-const START_Z = 10    // 카메라 초기 Z
+const CARD_WIDTH = 220
+const CARD_HEIGHT = 158  // 카드 렌더 높이 추정치 (엣지 연결점 계산용)
+const CARD_GAP_H = 24    // 같은 행 내 카드 간격
+const ROW_GAP = 80       // 행 간 수직 간격 (카드 아래 끝 ~ 다음 카드 위 시작)
+const PADDING_V = 48
+const PADDING_H = 40
+const TIME_BUCKET_MS = 10 * 60 * 1000  // 10분 이내 = 같은 행
 
-// 최신 노드 = Z 가까이, 오래된 노드 = Z 깊숙이
-function buildPositions(nodes: MemoData[]): Map<string, THREE.Vector3> {
+interface NodePos { x: number; y: number }
+
+// 노드를 시간 버킷(행)으로 그루핑, 픽셀 좌표 계산
+function computeLayout(nodes: MemoData[], containerWidth: number) {
+  if (nodes.length === 0) return { positions: new Map<string, NodePos>(), totalHeight: 400 }
+
+  // 오래된 것 → 위 (낮은 Y), 최신 → 아래 (높은 Y)
   const sorted = [...nodes].sort(
-    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-    // 최신순 정렬: index 0이 가장 최신 → z=0 (카메라에 가장 가까움)
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
   )
-  const goldenAngle = Math.PI * (3 - Math.sqrt(5)) // 2.4rad
-  const map = new Map<string, THREE.Vector3>()
-  sorted.forEach((node, i) => {
-    const z = -(i * Z_SPACING)
-    const r = Math.min(4, 0.5 + i * 0.5) // 반지름을 서서히 키우되 최대 4 제한
-    const angle = i * goldenAngle
-    map.set(
-      node.node_id,
-      new THREE.Vector3(r * Math.cos(angle), r * Math.sin(angle) * 0.6, z)
-    )
+
+  // 시간 버킷으로 그루핑
+  const rows: MemoData[][] = []
+  let current: MemoData[] = [sorted[0]]
+
+  for (let i = 1; i < sorted.length; i++) {
+    const dt =
+      new Date(sorted[i].created_at).getTime() -
+      new Date(sorted[i - 1].created_at).getTime()
+    if (dt > TIME_BUCKET_MS) {
+      rows.push(current)
+      current = []
+    }
+    current.push(sorted[i])
+  }
+  rows.push(current)
+
+  const positions = new Map<string, NodePos>()
+  let y = PADDING_V
+
+  rows.forEach((row) => {
+    // 행 내 카드들을 가로로 가운데 정렬
+    const rowWidth = row.length * CARD_WIDTH + (row.length - 1) * CARD_GAP_H
+    const startX = Math.max(PADDING_H, (containerWidth - rowWidth) / 2)
+
+    row.forEach((node, colIdx) => {
+      positions.set(node.node_id, {
+        x: startX + colIdx * (CARD_WIDTH + CARD_GAP_H),
+        y,
+      })
+    })
+
+    y += CARD_HEIGHT + ROW_GAP
   })
-  return map
+
+  return { positions, totalHeight: y + PADDING_V }
 }
 
-// ─── 카드 노드 ───────────────────────────────────────────────────────────────
+// SVG 엣지: 두 카드의 중심을 cubic bezier로 연결
+interface EdgePathProps {
+  from: NodePos
+  to: NodePos
+  score: number
+}
 
+function EdgePath({ from, to, score }: EdgePathProps) {
+  const sx = from.x + CARD_WIDTH / 2
+  const sy = from.y + CARD_HEIGHT / 2
+  const tx = to.x + CARD_WIDTH / 2
+  const ty = to.y + CARD_HEIGHT / 2
+
+  // 두 점 사이를 자연스럽게 잇는 cubic bezier
+  const dy = ty - sy
+  const vOffset = Math.max(50, Math.abs(dy) * 0.45)
+  const d = `M ${sx} ${sy} C ${sx} ${sy + vOffset}, ${tx} ${ty - vOffset}, ${tx} ${ty}`
+
+  return (
+    <path
+      d={d}
+      fill="none"
+      stroke="#a78bfa"
+      strokeWidth={0.8 + score * 1.8}
+      strokeOpacity={0.18 + score * 0.38}
+    />
+  )
+}
+
+// 메모 카드 (2D 뷰와 동일한 스타일)
 interface MemoCardProps {
   node: MemoData
-  position: THREE.Vector3
+  pos: NodePos
   selected: boolean
   onClick: () => void
 }
 
-function MemoCard({ node, position, selected, onClick }: MemoCardProps) {
+function MemoCard({ node, pos, selected, onClick }: MemoCardProps) {
   return (
-    <Html center distanceFactor={9} position={position} style={{ width: 210 }}>
+    <div
+      onClick={(e) => { e.stopPropagation(); onClick() }}
+      style={{
+        position: 'absolute',
+        left: pos.x,
+        top: pos.y,
+        width: CARD_WIDTH,
+        background: selected ? 'rgba(167,139,250,0.1)' : 'rgba(255,255,255,0.04)',
+        border: `1.5px solid ${selected ? '#a78bfa' : node.category_color + '88'}`,
+        borderRadius: 12,
+        padding: '10px 14px',
+        backdropFilter: 'blur(8px)',
+        boxShadow: selected
+          ? '0 0 20px rgba(167,139,250,0.25)'
+          : `0 0 10px ${node.category_color}22`,
+        cursor: 'pointer',
+        transition: 'border-color 0.15s, box-shadow 0.15s',
+        boxSizing: 'border-box',
+      }}
+    >
+      {/* 카테고리 컬러 */}
       <div
-        onClick={(e) => { e.stopPropagation(); onClick() }}
         style={{
-          width: 210,
-          background: selected ? 'rgba(167,139,250,0.1)' : 'rgba(14,12,28,0.75)',
-          border: `1.5px solid ${selected ? '#a78bfa' : node.category_color + '88'}`,
-          borderRadius: 12,
-          padding: '10px 14px',
-          backdropFilter: 'blur(12px)',
-          boxShadow: selected
-            ? '0 0 24px rgba(167,139,250,0.3), 0 4px 24px rgba(0,0,0,0.5)'
-            : `0 0 12px ${node.category_color}22, 0 4px 20px rgba(0,0,0,0.4)`,
-          cursor: 'pointer',
-          fontFamily: "'Pretendard', 'Inter', sans-serif",
-          transition: 'border-color 0.15s, box-shadow 0.15s',
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: node.category_color,
+          boxShadow: `0 0 6px ${node.category_color}88`,
+          marginBottom: 8,
+        }}
+      />
+
+      {/* 요약 */}
+      <p
+        style={{
+          color: '#f1f0f5',
+          fontSize: 12,
+          lineHeight: 1.65,
+          margin: 0,
+          display: '-webkit-box',
+          WebkitLineClamp: 3,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
         }}
       >
-        {/* 카테고리 컬러 인디케이터 */}
-        <div
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: '50%',
-            background: node.category_color,
-            boxShadow: `0 0 6px ${node.category_color}88`,
-            marginBottom: 8,
-          }}
-        />
+        {node.summary}
+      </p>
 
-        {/* 요약 */}
-        <p
-          style={{
-            color: '#f1f0f5',
-            fontSize: 12,
-            lineHeight: 1.65,
-            margin: 0,
-            display: '-webkit-box',
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {node.summary}
-        </p>
-
-        {/* 키워드 */}
-        {node.keywords.length > 0 && (
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 8 }}>
-            {node.keywords.slice(0, 3).map((kw) => (
-              <span
-                key={kw}
-                style={{
-                  fontSize: 10,
-                  padding: '1px 7px',
-                  borderRadius: 20,
-                  background: `${node.category_color}18`,
-                  color: node.category_color,
-                  border: `1px solid ${node.category_color}40`,
-                }}
-              >
-                {kw}
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
-    </Html>
-  )
-}
-
-// ─── 카메라 스크롤 컨트롤러 ─────────────────────────────────────────────────
-
-function CameraController({ nodeCount }: { nodeCount: number }) {
-  const { camera } = useThree()
-  const targetZ = useRef(START_Z)
-  const minZ = -(nodeCount - 1) * Z_SPACING - 8
-
-  useEffect(() => {
-    const handleWheel = (e: WheelEvent) => {
-      e.preventDefault()
-      // 아래로 스크롤 → 과거로 이동 (Z 감소)
-      targetZ.current = Math.max(
-        minZ,
-        Math.min(START_Z, targetZ.current - e.deltaY * 0.03)
-      )
-    }
-    window.addEventListener('wheel', handleWheel, { passive: false })
-    return () => window.removeEventListener('wheel', handleWheel)
-  }, [minZ])
-
-  useFrame(() => {
-    camera.position.z += (targetZ.current - camera.position.z) * 0.09
-  })
-
-  return null
-}
-
-// ─── 씬 ──────────────────────────────────────────────────────────────────────
-
-interface SceneProps {
-  nodes: MemoData[]
-  edges: {
-    edge_id: string
-    source_node_id: string
-    target_node_id: string
-    similarity_score: number
-  }[]
-  selectedNodeId: string | null
-  onNodeClick: (id: string) => void
-  onPaneClick: () => void
-}
-
-function Scene({ nodes, edges, selectedNodeId, onNodeClick, onPaneClick }: SceneProps) {
-  const positions = useMemo(() => buildPositions(nodes), [nodes])
-
-  return (
-    <>
-      {/* 엣지 (카드 뒤에 렌더링됨) */}
-      {edges.map((edge) => {
-        const from = positions.get(edge.source_node_id)
-        const to = positions.get(edge.target_node_id)
-        if (!from || !to) return null
-        return (
-          <Line
-            key={edge.edge_id}
-            points={[
-              from.toArray() as [number, number, number],
-              to.toArray() as [number, number, number],
-            ]}
-            color="#a78bfa"
-            lineWidth={0.4 + edge.similarity_score * 1.2}
-            opacity={0.1 + edge.similarity_score * 0.28}
-            transparent
-          />
-        )
-      })}
-
-      {/* 카드 노드 */}
-      {nodes.map((node) => {
-        const pos = positions.get(node.node_id)
-        if (!pos) return null
-        return (
-          <MemoCard
-            key={node.node_id}
-            node={node}
-            position={pos}
-            selected={node.node_id === selectedNodeId}
-            onClick={() => onNodeClick(node.node_id)}
-          />
-        )
-      })}
-
-      {/* 배경 클릭 → 패널 닫기 */}
-      <mesh position={[0, 0, -9999]} onClick={onPaneClick} visible={false}>
-        <planeGeometry args={[99999, 99999]} />
-        <meshBasicMaterial />
-      </mesh>
-
-      <CameraController nodeCount={nodes.length} />
-    </>
+      {/* 키워드 */}
+      {node.keywords.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 8 }}>
+          {node.keywords.slice(0, 3).map((kw) => (
+            <span
+              key={kw}
+              style={{
+                fontSize: 10,
+                padding: '1px 7px',
+                borderRadius: 20,
+                background: `${node.category_color}18`,
+                color: node.category_color,
+                border: `1px solid ${node.category_color}40`,
+              }}
+            >
+              {kw}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -210,22 +176,36 @@ function Scene({ nodes, edges, selectedNodeId, onNodeClick, onPaneClick }: Scene
 export default function TunnelView() {
   const { data, isLoading, isError } = useGraph()
   const { selectedNodeId, selectNode, closePanel } = useUiStore()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [containerWidth, setContainerWidth] = useState(900)
+
+  // 컨테이너 너비 감지
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const obs = new ResizeObserver((entries) => {
+      setContainerWidth(entries[0].contentRect.width)
+    })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [])
+
+  const { positions, totalHeight } = useMemo(
+    () => computeLayout(data?.nodes ?? [], containerWidth),
+    [data, containerWidth]
+  )
+
+  // 최신 메모(아래)로 초기 스크롤
+  useEffect(() => {
+    if (containerRef.current && data?.nodes.length) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+    }
+  }, [data])
 
   if (isLoading) {
     return (
-      <div
-        className="flex-1 flex items-center justify-center flex-col gap-3"
-        style={{ color: '#9b97b2' }}
-      >
-        <svg
-          className="animate-spin"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
+      <div className="flex-1 flex items-center justify-center flex-col gap-3" style={{ color: '#9b97b2' }}>
+        <svg className="animate-spin" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" strokeOpacity="0.3" />
           <path d="M21 12a9 9 0 00-9-9" />
         </svg>
@@ -244,41 +224,84 @@ export default function TunnelView() {
 
   if (!data || data.nodes.length === 0) {
     return (
-      <div
-        className="flex-1 flex items-center justify-center flex-col gap-3"
-        style={{ color: '#6b6880' }}
-      >
-        <div className="text-center">
-          <p className="text-sm font-medium" style={{ color: '#9b97b2' }}>
-            아직 메모가 없어요
-          </p>
-          <p className="text-xs mt-1">홈으로 돌아가 첫 메모를 작성해보세요</p>
-        </div>
+      <div className="flex-1 flex items-center justify-center flex-col gap-3" style={{ color: '#6b6880' }}>
+        <p className="text-sm font-medium" style={{ color: '#9b97b2' }}>아직 메모가 없어요</p>
+        <p className="text-xs">홈으로 돌아가 첫 메모를 작성해보세요</p>
       </div>
     )
   }
 
   return (
     <div className="flex-1 relative overflow-hidden">
-      <Canvas
-        camera={{ position: [0, 0, START_Z], fov: 55 }}
-        style={{ background: 'radial-gradient(ellipse at 50% 40%, #120a2a 0%, #07070f 70%)' }}
-        gl={{ antialias: true, alpha: false }}
+      {/* 스크롤 컨테이너 */}
+      <div
+        ref={containerRef}
+        onClick={closePanel}
+        style={{
+          width: '100%',
+          height: '100%',
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          position: 'relative',
+        }}
       >
-        <Scene
-          nodes={data.nodes}
-          edges={data.edges}
-          selectedNodeId={selectedNodeId}
-          onNodeClick={selectNode}
-          onPaneClick={closePanel}
-        />
-      </Canvas>
+        {/* 내부 캔버스 */}
+        <div
+          style={{
+            position: 'relative',
+            width: '100%',
+            height: totalHeight,
+          }}
+        >
+          {/* SVG 엣지 레이어 */}
+          <svg
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: totalHeight,
+              pointerEvents: 'none',
+              overflow: 'visible',
+            }}
+          >
+            {data.edges.map((edge) => {
+              const from = positions.get(edge.source_node_id)
+              const to = positions.get(edge.target_node_id)
+              if (!from || !to) return null
+              return (
+                <EdgePath
+                  key={edge.edge_id}
+                  from={from}
+                  to={to}
+                  score={edge.similarity_score}
+                />
+              )
+            })}
+          </svg>
 
-      {/* 스크롤 힌트 */}
+          {/* 카드 노드 레이어 */}
+          {data.nodes.map((node) => {
+            const pos = positions.get(node.node_id)
+            if (!pos) return null
+            return (
+              <MemoCard
+                key={node.node_id}
+                node={node}
+                pos={pos}
+                selected={node.node_id === selectedNodeId}
+                onClick={() => selectNode(node.node_id)}
+              />
+            )
+          })}
+        </div>
+      </div>
+
+      {/* 스크롤 힌트 (처음에만 표시) */}
       <div
         style={{
           position: 'absolute',
-          bottom: 24,
+          top: 16,
           left: '50%',
           transform: 'translateX(-50%)',
           color: '#4b4860',
@@ -289,17 +312,10 @@ export default function TunnelView() {
           gap: 6,
         }}
       >
-        <svg
-          width="12"
-          height="12"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          <path d="M12 5v14M5 12l7 7 7-7" />
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M12 19V5M5 12l7-7 7 7" />
         </svg>
-        스크롤 — 과거 메모로 이동
+        위로 스크롤 — 과거 메모 보기
       </div>
 
       {/* 노드 상세 패널 */}

--- a/src/components/graph/TunnelView.tsx
+++ b/src/components/graph/TunnelView.tsx
@@ -115,8 +115,11 @@ function MemoCard({ node, pos, selected, onClick }: MemoCardProps) {
           ? '0 0 20px rgba(167,139,250,0.25)'
           : `0 0 10px ${node.category_color}22`,
         cursor: 'pointer',
-        transition: 'border-color 0.15s, box-shadow 0.15s',
+        transition: 'border-color 0.2s, box-shadow 0.2s',
         boxSizing: 'border-box',
+        // 카드마다 위치 기반으로 딜레이·속도 다르게 → 제각각 둥실둥실
+        animation: `floatY ${3.2 + (pos.x * 0.0011 + pos.y * 0.0007) % 1.4}s ease-in-out infinite`,
+        animationDelay: `-${(pos.x * 0.004 + pos.y * 0.003) % 3.5}s`,
       }}
     >
       {/* 카테고리 컬러 */}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -2,17 +2,7 @@ import { useUiStore } from '../../store/useUiStore'
 import Sidebar from './Sidebar'
 import HomeView from '../home/HomeView'
 import GraphView from '../graph/GraphView'
-
-function TunnelView() {
-  return (
-    <div className="flex-1 flex items-center justify-center" style={{ color: '#6b6880' }}>
-      <div className="text-center flex flex-col gap-2">
-        <span className="text-4xl">🌀</span>
-        <p className="text-sm">3D 터널 뷰 — Phase 5에서 구현 예정</p>
-      </div>
-    </div>
-  )
-}
+import TunnelView from '../graph/TunnelView'
 
 export default function AppLayout() {
   const viewMode = useUiStore((s) => s.viewMode)

--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,11 @@
   }
 }
 
+@keyframes floatY {
+  0%, 100% { transform: translateY(0px) rotate(0deg); }
+  50% { transform: translateY(-7px) rotate(0.4deg); }
+}
+
 @keyframes slideInRight {
   from {
     opacity: 0;


### PR DESCRIPTION
## Summary
- `TunnelView`: React Three Fiber 기반 3D 터널 시각화
- 노드를 생성 시간순으로 Z축에 배치 (최신 = 가까이, 오래된 것 = 터널 안쪽)
- 황금각(2.4rad) 나선 배치로 노드가 자연스럽게 분산
- 마우스 휠 → 카메라 Z 이동 (lerp 보간으로 부드럽게)
- 엣지: 유사도 비례 굵기/투명도, 터널 링 장식 + fog 원근감

## Test plan
- [ ] 로그인 후 메모 3개 이상 작성
- [ ] 사이드바 3D 아이콘 클릭 → 터널 뷰 렌더링 확인
- [ ] 마우스 휠 스크롤로 카메라 이동 확인
- [ ] 노드 클릭 → 우측 상세 패널 확인
- [ ] 빈 상태 안내 화면 확인